### PR TITLE
Fix Javadoc formatting for JDK 8

### DIFF
--- a/pkg-calabash/src/org/expath/pkg/calabash/CalabashPkgExtension.java
+++ b/pkg-calabash/src/org/expath/pkg/calabash/CalabashPkgExtension.java
@@ -33,15 +33,15 @@ import org.expath.pkg.repo.parser.XMLStreamHelper;
  * The extension descriptor "calabash.xml" must be at the root of the package.
  * Its format is as following:
  * 
- * <pre>
- * &lt;package xmlns="http://saxon.sf.net/ns/expath-pkg">
- *    &lt;jar>dir/file.jar&lt;/jar>
- *    &lt;step>
- *       &lt;type>{http://example.org/ns/project}my-step-type&lt;/type>
- *       &lt;class>org.example.extension.MyStep&lt;/class>
- *    &lt;/step>
- * &lt;/package>
- * </pre>
+ * <pre>{@code
+ * <package xmlns="http://saxon.sf.net/ns/expath-pkg">
+ *    <jar>dir/file.jar</jar>
+ *    <step>
+ *       <type>{http://example.org/ns/project}my-step-type</type>
+ *       <class>org.example.extension.MyStep</class>
+ *    </step>
+ * </package>
+ * }</pre>
  *
  * The elements "jar" and "step" are optional, repeatable, and can appear in any
  * order.  The element "jar" links to the JAR files, in the content directory,

--- a/pkg-calabash/src/org/expath/pkg/calabash/Version.java
+++ b/pkg-calabash/src/org/expath/pkg/calabash/Version.java
@@ -17,7 +17,7 @@ import java.util.Properties;
  * Version of this project.
  *
  * @author Florent Georges
- * @date   2013-09-10
+ * Created 2013-09-10
  */
 public class Version
 {

--- a/pkg-java/src/org/expath/pkg/repo/rsrc/add-package.xsl
+++ b/pkg-java/src/org/expath/pkg/repo/rsrc/add-package.xsl
@@ -6,9 +6,9 @@
 
    <xsl:output indent="yes"/>
 
-   <xsl:param name="name"    select="/.."/>
-   <xsl:param name="dir"     select="/.."/>
-   <xsl:param name="version" select="/.."/>
+   <xsl:param name="name"/>
+   <xsl:param name="dir"/>
+   <xsl:param name="version"/>
 
    <xsl:template match="node()">
       <xsl:copy>

--- a/pkg-java/src/org/expath/pkg/repo/rsrc/remove-package.xsl
+++ b/pkg-java/src/org/expath/pkg/repo/rsrc/remove-package.xsl
@@ -6,7 +6,7 @@
 
    <xsl:output indent="yes"/>
 
-   <xsl:param name="dir" select="/.."/>
+   <xsl:param name="dir"/>
 
    <xsl:template match="node()" priority="-1">
       <xsl:copy>


### PR DESCRIPTION
Previous javadoc formatting causes the javadoc generation to fail on JDK 8